### PR TITLE
DS-2876 Return standard errors in Correlation test [revdep skip]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,5 +22,5 @@ Remotes:
     Displayr/flipFormat,
     Displayr/flipTransformations,
     Displayr/rhtmlHeatmap
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStatistics
 Type: Package
 Title: Computes standard statistics (e.g., mean, standard deviation.)
-Version: 1.0.0
+Version: 1.0.1
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Computes standard statistics, dealing with situations not addressed

--- a/R/covariancecorrelation.R
+++ b/R/covariancecorrelation.R
@@ -136,6 +136,7 @@ CorrelationsWithSignificance <- function(data, weights, spearman = FALSE)
     correlations <- mtrx
     t.stats <- mtrx
     p.values <- mtrx
+    std.errs <- mtrx
     not.na.weights <- !is.na(weights)
     for (i in 1:n)
     {
@@ -155,17 +156,21 @@ CorrelationsWithSignificance <- function(data, weights, spearman = FALSE)
                     correlations[i, j] <- NaN
                     t.stats[i, j] <- NA
                     p.values[i, j] <- NA
+                    std.errs[i, j] <- NA
                 }
                 else
                 {
                     dsgn <- svydesign(ids = ~1, weights = wgt, data = pair)
                     v <- svyvar(pair, dsgn)
-                    correlations[i, j] <- v[1, 2] / sqrt(v[1, 1] * v[2, 2])
+                    tmp.val <- sqrt(v[1, 1] * v[2, 2])
+                    correlations[i, j] <- v[1, 2] / tmp.val
                     t.stats[i, j] <- v[1, 2] / SE(v)[2]
+                    std.errs[i, j] <- SE(v)[2] / tmp.val
                     p.values[i, j] <- 2 * suppressWarnings(pt(-abs(t.stats[i, j]), sum(ind) - 2))
                 }
                 correlations[j, i] <- correlations[i, j]
                 t.stats[j, i] <- t.stats[i, j]
+                std.errs[j, i] <- std.errs[i, j]
                 p.values[j, i] <- p.values[i, j]
             }
             else
@@ -173,10 +178,11 @@ CorrelationsWithSignificance <- function(data, weights, spearman = FALSE)
                 correlations[i, i] <- 1
                 t.stats[i, i] <- Inf
                 p.values[i, i] <- 0
+                std.errs[i, i] <- 0
             }
         }
     }
-    list(cor = correlations, t = t.stats, p = p.values)
+    list(cor = correlations, t = t.stats, p = p.values, standard.errors = std.errs)
 }
 
 #' \code{SpearmanRanks}

--- a/man/CorrelationMatrix.Rd
+++ b/man/CorrelationMatrix.Rd
@@ -4,12 +4,23 @@
 \alias{CorrelationMatrix}
 \title{\code{CorrelationMatrix}}
 \usage{
-CorrelationMatrix(input.data, use.names = FALSE, ignore.columns = "",
-  missing.data = "Use partial data", spearman = FALSE, filter = NULL,
-  weights = NULL, show.cell.values = "Automatic", colors = NULL,
-  colors.min.value = -1, colors.max.value = 1, row.labels = "Yes",
-  column.labels = "Yes", input.type = NULL,
-  categorical.as.binary = FALSE)
+CorrelationMatrix(
+  input.data,
+  use.names = FALSE,
+  ignore.columns = "",
+  missing.data = "Use partial data",
+  spearman = FALSE,
+  filter = NULL,
+  weights = NULL,
+  show.cell.values = "Automatic",
+  colors = NULL,
+  colors.min.value = -1,
+  colors.max.value = 1,
+  row.labels = "Yes",
+  column.labels = "Yes",
+  input.type = NULL,
+  categorical.as.binary = FALSE
+)
 }
 \arguments{
 \item{input.data}{Either a \code{\link{data.frame}}, a \code{\link{list}} of

--- a/man/CovarianceAndCorrelationMatrix.Rd
+++ b/man/CovarianceAndCorrelationMatrix.Rd
@@ -4,8 +4,12 @@
 \alias{CovarianceAndCorrelationMatrix}
 \title{\code{CovarianceAndCorrelationMatrix}}
 \usage{
-CovarianceAndCorrelationMatrix(data, weights = NULL, pairwise = FALSE,
-  use.correlation = TRUE)
+CovarianceAndCorrelationMatrix(
+  data,
+  weights = NULL,
+  pairwise = FALSE,
+  use.correlation = TRUE
+)
 }
 \arguments{
 \item{data}{A data frame containing the input data.}

--- a/man/Multiway.Rd
+++ b/man/Multiway.Rd
@@ -4,9 +4,16 @@
 \alias{Multiway}
 \title{\code{Multiway}}
 \usage{
-Multiway(rows, columns = NULL, numeric = NULL,
-  numeric.statistic = "Mean", hide.empty.rows = FALSE,
-  hide.empty.columns = FALSE, subset = NULL, weights = NULL)
+Multiway(
+  rows,
+  columns = NULL,
+  numeric = NULL,
+  numeric.statistic = "Mean",
+  hide.empty.rows = FALSE,
+  hide.empty.columns = FALSE,
+  subset = NULL,
+  weights = NULL
+)
 }
 \arguments{
 \item{rows}{A \code{\link{data.frame}} of variables to show in the rows of the table.}

--- a/man/WeightedTable.Rd
+++ b/man/WeightedTable.Rd
@@ -4,9 +4,14 @@
 \alias{WeightedTable}
 \title{\code{WeightedTable}}
 \usage{
-WeightedTable(..., weights = NULL, exclude = if (useNA == "no") c(NA,
-  NaN), useNA = c("no", "ifany", "always"), dnn = list.names(...),
-  deparse.level = 1)
+WeightedTable(
+  ...,
+  weights = NULL,
+  exclude = if (useNA == "no") c(NA, NaN),
+  useNA = c("no", "ifany", "always"),
+  dnn = list.names(...),
+  deparse.level = 1
+)
 }
 \arguments{
 \item{...}{one or more objects which can be interpretated as factors, or a list or dataframe whose components can be so interpreted}

--- a/tests/testthat/test-covariancecorrelation.R
+++ b/tests/testthat/test-covariancecorrelation.R
@@ -82,8 +82,10 @@ test_that("Correlation",
 
 test_that("Correlation significance",
 {
-    expect_equal(CorrelationsWithSignificance(test.data.1, test.weight)$cor[3,4], 0.151448808216322)
-    expect_equal(CorrelationsWithSignificance(test.data.1, test.weight)$p[3,4], 0.1227358415903436)
+    test.output <- CorrelationsWithSignificance(test.data.1, test.weight)
+    expect_equal(test.output$cor[3,4], 0.151448808216322)
+    expect_equal(test.output$p[3,4], 0.1227358415903436)
+    expect_true(all.equal(test.output$t, test.output$cor/test.output$standard.errors))
     expect_equal(CorrelationsWithSignificance(test.data.1, test.weight, spearman = TRUE)$cor[3,4], 0.1534977186961468)
     expect_equal(CorrelationsWithSignificance(test.data.1, test.weight, spearman = TRUE)$p[3,4], 0.09251195118913291)
 })

--- a/tests/testthat/test-multiway.R
+++ b/tests/testthat/test-multiway.R
@@ -64,7 +64,7 @@ test_that("Data types for the numeric variable should be passed when reading in 
           {
               data(phone, package = "flipExampleData")
               attach(phone)
-            Multiway(list(q2, q3), list(q4), q25)
+            expect_error(Multiway(list(q2, q3), list(q4), q25), NA)
               detach(phone)
     # if (length(formNumeric) == 1) NULL else formNumeric,
     # numeric.statistic = formStatistic,


### PR DESCRIPTION
For use in the Correlation output in Regression, the standard errors for
the significance tests are requied and returned in the output. Unit tests
added to ensure returned standard errors are consistent with the
correlation values and their t-statistics that are already returned.
Documentation updated to roxygen 7.1.0 also.