### PR TITLE
DPI-2897 Package flipStatistics in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipStatistics";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''Computes standard statistics, dealing with situations not addressed
+    in base R. E.g., weighting, non-standard data structures.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    flipTransformations
+    flipFormat
+    rhtmlHeatmap
+    verbs
+    flipU
+    survey
+  ];
+}

--- a/package.nix
+++ b/package.nix
@@ -4,8 +4,10 @@ pkgs.rPackages.buildRPackage {
   name = "flipStatistics";
   version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
   src = ./.;
-  description = ''Computes standard statistics, dealing with situations not addressed
-    in base R. E.g., weighting, non-standard data structures.'';
+  description = ''
+    Computes standard statistics, dealing with situations not addressed
+    in base R. E.g., weighting, non-standard data structures.
+  '';
   propagatedBuildInputs = with pkgs.rPackages; [ 
     flipTransformations
     flipFormat


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipStatistics in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR